### PR TITLE
Add interactive daily challenge runner

### DIFF
--- a/src/components/DailyChallengePanel.tsx
+++ b/src/components/DailyChallengePanel.tsx
@@ -1,13 +1,40 @@
+import { useState } from 'react';
 import { motion } from 'framer-motion';
-import { DailyChallenge } from '../types';
+import { DailyChallenge, DailyChallengeRunSummary } from '../types';
+import { DailyChallengeRunner } from './DailyChallengeRunner';
 
 interface DailyChallengePanelProps {
   challenge: DailyChallenge;
   completed: boolean;
-  onComplete: (challenge: DailyChallenge) => void;
+  onComplete: (challenge: DailyChallenge, summary: DailyChallengeRunSummary) => void;
+  summary?: DailyChallengeRunSummary | null;
 }
 
-export const DailyChallengePanel = ({ challenge, completed, onComplete }: DailyChallengePanelProps) => {
+const formatDuration = (seconds: number) => {
+  const minutes = Math.floor(seconds / 60);
+  const secs = Math.floor(seconds % 60)
+    .toString()
+    .padStart(2, '0');
+  return `${minutes}:${secs}`;
+};
+
+export const DailyChallengePanel = ({ challenge, completed, onComplete, summary }: DailyChallengePanelProps) => {
+  const [showRunner, setShowRunner] = useState(false);
+
+  const handleLaunch = () => {
+    if (completed) return;
+    setShowRunner(true);
+  };
+
+  const handleClose = () => {
+    setShowRunner(false);
+  };
+
+  const handleComplete = (runChallenge: DailyChallenge, runSummary: DailyChallengeRunSummary) => {
+    onComplete(runChallenge, runSummary);
+    setShowRunner(false);
+  };
+
   return (
     <section className="bg-white/5 border border-white/10 rounded-3xl px-6 py-6 h-full flex flex-col">
       <div className="flex items-center justify-between mb-4">
@@ -33,7 +60,7 @@ export const DailyChallengePanel = ({ challenge, completed, onComplete }: DailyC
         whileHover={{ scale: completed ? 1 : 1.03 }}
         whileTap={{ scale: completed ? 1 : 0.97 }}
         disabled={completed}
-        onClick={() => onComplete(challenge)}
+        onClick={handleLaunch}
         className={`mt-6 inline-flex items-center justify-center rounded-full px-6 py-3 font-semibold transition-all ${
           completed
             ? 'bg-white/10 text-slate-300 border border-white/10 cursor-not-allowed'
@@ -42,6 +69,52 @@ export const DailyChallengePanel = ({ challenge, completed, onComplete }: DailyC
       >
         {completed ? 'Challenge Completed' : `Start Challenge (+${challenge.reward.points} pts)`}
       </motion.button>
+
+      {summary && summary.challengeId === challenge.id && (
+        <div className="mt-5 rounded-2xl border border-white/10 bg-white/5 p-4 text-sm text-slate-200">
+          <div className="flex items-center justify-between">
+            <p className="font-semibold text-white">Last run recap</p>
+            <span className="text-xs uppercase tracking-widest text-slate-400">
+              {formatDuration(summary.timeElapsedSeconds)} spent
+            </span>
+          </div>
+
+          <dl className="mt-4 grid grid-cols-3 gap-3">
+            <div>
+              <dt className="text-xs uppercase tracking-widest text-slate-400">Solved</dt>
+              <dd className="mt-1 text-lg font-semibold text-white">{summary.solved}</dd>
+            </div>
+            <div>
+              <dt className="text-xs uppercase tracking-widest text-slate-400">Accuracy</dt>
+              <dd className="mt-1 text-lg font-semibold text-aurora">{summary.accuracy}%</dd>
+            </div>
+            <div>
+              <dt className="text-xs uppercase tracking-widest text-slate-400">Best combo</dt>
+              <dd className="mt-1 text-lg font-semibold text-ember">
+                {summary.bestCombo > 0 ? `x${summary.bestCombo}` : '—'}
+              </dd>
+            </div>
+          </dl>
+
+          {summary.completed && summary.allSolved && summary.bestCombo > 0 && (
+            <p className="mt-3 text-xs text-aurora">
+              Full clear! Combo streak peaked at x{summary.bestCombo}.
+            </p>
+          )}
+
+          {!summary.allSolved && (
+            <p className="mt-3 text-xs text-slate-300">
+              Session closed with {summary.solved} prompts answered—try again tomorrow to push the streak higher.
+            </p>
+          )}
+        </div>
+      )}
+
+      <DailyChallengeRunner
+        challenge={showRunner ? challenge : null}
+        onClose={handleClose}
+        onComplete={handleComplete}
+      />
     </section>
   );
 };

--- a/src/components/DailyChallengeRunner.tsx
+++ b/src/components/DailyChallengeRunner.tsx
@@ -1,0 +1,268 @@
+import { AnimatePresence, motion } from 'framer-motion';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  DailyChallenge,
+  DailyChallengePrompt,
+  DailyChallengeRunResult,
+  DailyChallengeRunSummary,
+} from '../types';
+
+interface DailyChallengeRunnerProps {
+  challenge: DailyChallenge | null;
+  onClose: () => void;
+  onComplete: (challenge: DailyChallenge, summary: DailyChallengeRunSummary) => void;
+}
+
+const formatTime = (value: number) => {
+  const minutes = Math.floor(value / 60)
+    .toString()
+    .padStart(2, '0');
+  const seconds = Math.floor(value % 60)
+    .toString()
+    .padStart(2, '0');
+  return `${minutes}:${seconds}`;
+};
+
+export const DailyChallengeRunner = ({ challenge, onClose, onComplete }: DailyChallengeRunnerProps) => {
+  const prompts = useMemo<DailyChallengePrompt[]>(() => {
+    if (!challenge) return [];
+    if (challenge.prompts && challenge.prompts.length > 0) {
+      return challenge.prompts;
+    }
+
+    return challenge.tasks.map((task, index) => ({
+      id: `${challenge.id}-${index}`,
+      question: task,
+      choices: ['Completed', 'Need more time'],
+      correctIndex: 0,
+    }));
+  }, [challenge]);
+
+  const totalSeconds = (challenge?.timeLimitMinutes ?? 0) * 60;
+
+  const [timeRemaining, setTimeRemaining] = useState(totalSeconds);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [results, setResults] = useState<DailyChallengeRunResult[]>([]);
+  const [combo, setCombo] = useState(0);
+  const [selectedChoice, setSelectedChoice] = useState<number | null>(null);
+  const [showFeedback, setShowFeedback] = useState(false);
+  const [hasFinished, setHasFinished] = useState(false);
+
+  useEffect(() => {
+    if (!challenge) return;
+    setTimeRemaining(challenge.timeLimitMinutes * 60);
+    setCurrentIndex(0);
+    setResults([]);
+    setCombo(0);
+    setSelectedChoice(null);
+    setShowFeedback(false);
+    setHasFinished(false);
+  }, [challenge]);
+
+  const finalizeRun = useCallback(
+    (finalResults: DailyChallengeRunResult[], completed: boolean) => {
+      if (!challenge || hasFinished) return;
+
+      const solved = finalResults.length;
+      const correct = finalResults.filter((item) => item.correct).length;
+      let bestCombo = 0;
+      let streak = 0;
+      finalResults.forEach((item) => {
+        if (item.correct) {
+          streak += 1;
+          bestCombo = Math.max(bestCombo, streak);
+        } else {
+          streak = 0;
+        }
+      });
+      const allSolved = finalResults.length === prompts.length;
+
+      const summary: DailyChallengeRunSummary = {
+        challengeId: challenge.id,
+        solved,
+        correct,
+        accuracy: solved === 0 ? 0 : Math.round((correct / solved) * 100),
+        bestCombo,
+        completed,
+        allSolved,
+        timeElapsedSeconds: Math.max(0, challenge.timeLimitMinutes * 60 - timeRemaining),
+        results: finalResults,
+      };
+
+      setHasFinished(true);
+      onComplete(challenge, summary);
+      onClose();
+    },
+    [challenge, hasFinished, onClose, onComplete, prompts.length, timeRemaining]
+  );
+
+  useEffect(() => {
+    if (!challenge || hasFinished) return;
+    if (timeRemaining <= 0) {
+      finalizeRun(results, true);
+      return;
+    }
+
+    const interval = window.setInterval(() => {
+      setTimeRemaining((prev) => (prev > 0 ? prev - 1 : 0));
+    }, 1000);
+
+    return () => window.clearInterval(interval);
+  }, [challenge, finalizeRun, hasFinished, prompts.length, results, timeRemaining]);
+
+  const handleSelect = (choiceIndex: number) => {
+    if (!challenge) return;
+    if (selectedChoice !== null) return;
+
+    const prompt = prompts[currentIndex];
+    if (!prompt) return;
+
+    const correct = choiceIndex === prompt.correctIndex;
+    const nextResult: DailyChallengeRunResult = { promptId: prompt.id, correct };
+
+    setResults((prev) => [...prev, nextResult]);
+    setCombo((prev) => (correct ? prev + 1 : 0));
+    setSelectedChoice(choiceIndex);
+    setShowFeedback(true);
+  };
+
+  const handleNext = () => {
+    if (currentIndex >= prompts.length - 1) {
+      finalizeRun(results, true);
+      return;
+    }
+
+    setCurrentIndex((prev) => prev + 1);
+    setSelectedChoice(null);
+    setShowFeedback(false);
+  };
+
+  const answeredCount = results.length;
+  const accuracy = answeredCount
+    ? Math.round((results.filter((result) => result.correct).length / answeredCount) * 100)
+    : 0;
+  const currentPrompt = prompts[currentIndex];
+  const progress = prompts.length === 0 ? 0 : Math.min(100, (answeredCount / prompts.length) * 100);
+  const lastResult = results[results.length - 1];
+  const showHint = showFeedback && lastResult && !lastResult.correct && currentPrompt?.hint;
+
+  return (
+    <AnimatePresence>
+      {challenge && (
+        <motion.div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-midnight/80 backdrop-blur"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+        >
+          <motion.div
+            initial={{ opacity: 0, y: 40 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 40 }}
+            transition={{ type: 'spring', stiffness: 160, damping: 18 }}
+            className="relative w-full max-w-2xl rounded-3xl border border-white/10 bg-midnight/90 p-8 text-white shadow-glow"
+          >
+            <header className="flex flex-col gap-4 border-b border-white/10 pb-4 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <p className="text-xs uppercase tracking-[0.25em] text-slate-400">Now playing</p>
+                <h2 className="font-display text-2xl text-white">{challenge.title}</h2>
+              </div>
+              <div className="flex items-center gap-4 text-sm text-slate-200">
+                <span className="rounded-full border border-aurora/50 bg-aurora/10 px-4 py-1 font-semibold text-aurora">
+                  {formatTime(timeRemaining)}
+                </span>
+                <span className="text-slate-300">Accuracy {accuracy}%</span>
+              </div>
+            </header>
+
+            <div className="mt-6">
+              <div className="h-2 w-full overflow-hidden rounded-full bg-white/10">
+                <div
+                  className="h-full rounded-full bg-gradient-to-r from-aurora to-ember transition-all"
+                  style={{ width: `${progress}%` }}
+                />
+              </div>
+              <div className="mt-3 flex items-center justify-between text-xs uppercase tracking-widest text-slate-400">
+                <span>
+                  Question {Math.min(answeredCount + 1, prompts.length)} / {prompts.length}
+                </span>
+                <span>Combo streak: {combo}</span>
+              </div>
+            </div>
+
+            <div className="mt-6 space-y-5">
+              {currentPrompt ? (
+                <>
+                  <motion.h3 layout className="font-display text-xl text-white">
+                    {currentPrompt.question}
+                  </motion.h3>
+                  <div className="grid gap-3">
+                    {currentPrompt.choices.map((choice, index) => {
+                      const isSelected = selectedChoice === index;
+                      const isCorrectChoice = currentPrompt.correctIndex === index;
+                      const showState = showFeedback && (isSelected || isCorrectChoice);
+
+                      return (
+                        <motion.button
+                          key={choice}
+                          whileHover={{ scale: selectedChoice === null ? 1.02 : 1 }}
+                          whileTap={{ scale: selectedChoice === null ? 0.98 : 1 }}
+                          disabled={selectedChoice !== null}
+                          onClick={() => handleSelect(index)}
+                          className={`rounded-2xl border px-4 py-3 text-left text-sm font-medium transition-all ${
+                            showState
+                              ? isCorrectChoice
+                                ? 'border-aurora bg-aurora/10 text-aurora'
+                                : 'border-ember bg-ember/10 text-ember'
+                              : 'border-white/10 bg-white/5 text-slate-100 hover:border-aurora/40 hover:bg-aurora/10'
+                          }`}
+                        >
+                          {choice}
+                        </motion.button>
+                      );
+                    })}
+                  </div>
+
+                  {showFeedback && lastResult && (
+                    <div
+                      className={`rounded-2xl border px-4 py-3 text-sm ${
+                        lastResult.correct
+                          ? 'border-aurora/40 bg-aurora/10 text-aurora'
+                          : 'border-ember/40 bg-ember/10 text-ember'
+                      }`}
+                    >
+                      {lastResult.correct ? 'Nice! Combo climbing.' : 'Combo reset. Shake it off and keep going!'}
+                      {showHint && <p className="mt-2 text-xs text-slate-200">Hint: {currentPrompt.hint}</p>}
+                    </div>
+                  )}
+                </>
+              ) : (
+                <p className="text-center text-sm text-slate-300">
+                  No prompts available for this challenge just yet.
+                </p>
+              )}
+            </div>
+
+            <footer className="mt-8 flex justify-end">
+              {showFeedback ? (
+                <button
+                  onClick={handleNext}
+                  className="inline-flex items-center rounded-full bg-gradient-to-r from-aurora to-ember px-6 py-2 text-sm font-semibold text-midnight shadow-glow"
+                >
+                  {currentIndex >= prompts.length - 1 ? 'Finish Run' : 'Next Prompt'}
+                </button>
+              ) : (
+                <button
+                  onClick={() => finalizeRun(results, false)}
+                  className="inline-flex items-center rounded-full border border-white/20 px-6 py-2 text-sm font-semibold text-slate-200 transition hover:border-ember/60 hover:text-ember"
+                >
+                  Exit Session
+                </button>
+              )}
+            </footer>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+};

--- a/src/data/dailyChallenges.ts
+++ b/src/data/dailyChallenges.ts
@@ -16,6 +16,27 @@ export const dailyChallenges: DailyChallenge[] = [
       'Balance a linear equation before the timer blinks red.',
       'Approximate the area of a polygon by decomposing shapes.',
     ],
+    prompts: [
+      {
+        id: 'speed-sprint-1',
+        question: 'What is the probability of drawing two hearts consecutively from a standard 52-card deck without replacement?',
+        choices: ['(13/52) × (12/51)', '(13/52) × (13/52)', '(1/4) × (1/4)'],
+        correctIndex: 0,
+        hint: 'Remember that the total card count changes after the first draw.',
+      },
+      {
+        id: 'speed-sprint-2',
+        question: 'Solve for x: 3x - 4 = 2x + 5.',
+        choices: ['x = 9', 'x = -9', 'x = 1/9'],
+        correctIndex: 0,
+      },
+      {
+        id: 'speed-sprint-3',
+        question: 'A hexagon is decomposed into four congruent triangles each with area 6. What is the total area of the hexagon?',
+        choices: ['12', '18', '24'],
+        correctIndex: 2,
+      },
+    ],
   },
   {
     id: 'strategy-lab',
@@ -32,6 +53,26 @@ export const dailyChallenges: DailyChallenge[] = [
       'Design a diversified allocation for a $10k portfolio.',
       'Calculate expected outcomes for a product launch gamble.',
     ],
+    prompts: [
+      {
+        id: 'strategy-lab-1',
+        question: 'If Topic A has a 0.6 probability of appearing and Topic B has 0.4, which schedule maximizes expected coverage in 5 study blocks?',
+        choices: ['3 blocks for A, 2 for B', '4 blocks for B, 1 for A', 'Evenly split: 2.5 blocks each'],
+        correctIndex: 0,
+      },
+      {
+        id: 'strategy-lab-2',
+        question: 'A balanced $10k portfolio aims for 40% equities, 35% bonds, and the rest cash. How much is allocated to bonds?',
+        choices: ['$3,500', '$4,000', '$2,500'],
+        correctIndex: 0,
+      },
+      {
+        id: 'strategy-lab-3',
+        question: 'Launching a product has a 30% chance of high success ($12k gain) and 70% chance of low success ($3k gain). What is the expected gain?',
+        choices: ['$5,100', '$7,500', '$9,000'],
+        correctIndex: 0,
+      },
+    ],
   },
   {
     id: 'mystery-easter-egg',
@@ -47,6 +88,27 @@ export const dailyChallenges: DailyChallenge[] = [
       'Translate the pattern into a Fibonacci-like series.',
       'Predict the next glyph rotation angle.',
       'Explain the rule in 30 seconds to secure the badge.',
+    ],
+    prompts: [
+      {
+        id: 'mystery-easter-egg-1',
+        question: 'The signal shows 2, 3, 5, 8... What number continues the pattern?',
+        choices: ['11', '12', '13'],
+        correctIndex: 2,
+        hint: 'Each value is the sum of the previous two.',
+      },
+      {
+        id: 'mystery-easter-egg-2',
+        question: 'Glyph rotations increase by 45°. After 135°, what is the next angle?',
+        choices: ['150°', '180°', '225°'],
+        correctIndex: 1,
+      },
+      {
+        id: 'mystery-easter-egg-3',
+        question: 'To explain the rule quickly, what is the clearest summary?',
+        choices: ['The sequence doubles each step.', 'Each term is the sum of the prior two, mirrored by 45° rotations.', 'Every odd term repeats.'],
+        correctIndex: 1,
+      },
     ],
   },
 ];

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,31 @@ export interface LearningModule {
   miniGame: ModuleMiniGame;
 }
 
+export interface DailyChallengePrompt {
+  id: string;
+  question: string;
+  choices: string[];
+  correctIndex: number;
+  hint?: string;
+}
+
+export interface DailyChallengeRunResult {
+  promptId: string;
+  correct: boolean;
+}
+
+export interface DailyChallengeRunSummary {
+  challengeId: string;
+  solved: number;
+  correct: number;
+  accuracy: number;
+  bestCombo: number;
+  completed: boolean;
+  allSolved: boolean;
+  timeElapsedSeconds: number;
+  results: DailyChallengeRunResult[];
+}
+
 export interface DailyChallenge {
   id: string;
   title: string;
@@ -47,6 +72,10 @@ export interface DailyChallenge {
     streakBonus?: number;
   };
   tasks: string[];
+  prompts?: DailyChallengePrompt[];
+  scoring?: {
+    comboBonus?: number;
+  };
 }
 
 export interface RewardBadge {


### PR DESCRIPTION
## Summary
- add a DailyChallengeRunner modal that guides timed prompts, tracks accuracy/combo, and emits run summaries
- update the DailyChallengePanel and App flow to launch the runner, display recap stats, and feed summaries into streak rewards
- extend daily challenge types and seed prompt content so the runner can step through structured questions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd75960afc832f89d4ad9eb9715895