### PR TITLE
Add Probability Forest scenario simulator and rewards integration

### DIFF
--- a/docs/scenario-authoring.md
+++ b/docs/scenario-authoring.md
@@ -1,0 +1,99 @@
+# Scenario Authoring Guide
+
+The scenario simulator pulls its content from the structured JSON schema in [`src/data/scenarios.ts`](../src/data/scenarios.ts). Each entry keeps the learning arc tight with the existing module lore while defining the sliders, copy, and rewards that surface inside the UI.
+
+## File layout
+
+```text
+src/
+  data/
+    scenarios.ts    ← ScenarioDefinition objects live here
+  components/
+    ScenarioShowcase.tsx
+    ScenarioSimulator.tsx
+```
+
+The showcase reads the library, renders persona-specific cards, and routes the selected entry to the simulator. The simulator renders each parameter as an interactive slider, gives live feedback, and checks whether every target range is satisfied before the learner can claim rewards.
+
+## ScenarioDefinition schema
+
+Each scenario exported from `scenarioLibrary` must satisfy the `ScenarioDefinition` interface in [`src/types.ts`](../src/types.ts):
+
+```ts
+interface ScenarioDefinition {
+  id: string;                       // Unique key used for persistence
+  title: string;                    // Display title on cards and simulator
+  icon: string;                     // Emoji or glyph shown on the card
+  accent: string;                   // Tailwind gradient classes for card overlay
+  moduleContext: {
+    id: string;                     // Module identifier (e.g. 'probability-forest')
+    name: string;                   // Friendly module name
+    insight: string;                // Short line linking the scenario back to the module
+  };
+  personas: Record<Audience, ScenarioPersonaContent>;
+  parameters: ScenarioParameter[];  // Slider configuration and live feedback copy
+  success: {
+    summary: string;                // High-level success statement shown in the footer
+    checkpoints: string[];          // Bullet list describing the objective
+  };
+  reward: {
+    points: number;                 // Points to add to the learner profile
+    badgeId?: string;               // Optional badge id that is granted on success
+    celebration: string;            // Pulse message broadcast after completion
+  };
+}
+```
+
+### Persona-specific content
+
+`ScenarioPersonaContent` lets you tailor card copy, baseline inputs, and objectives per audience:
+
+```ts
+interface ScenarioPersonaContent {
+  cardDescription: string;                      // Card teaser text
+  narrative: string;                            // Simulator intro paragraph
+  objective: string;                            // Highlighted objective text
+  baseline: { label: string; value: string; helper: string }[]; // Baseline metrics table
+}
+```
+
+Provide entries for both `college` and `professional` so each persona receives resonant framing.
+
+### Adjustable parameters
+
+Each slider is defined by a `ScenarioParameter`:
+
+```ts
+interface ScenarioParameter {
+  id: string;                         // Unique per scenario
+  label: string;                      // Slider heading
+  description: string;                // Supporting copy under the heading
+  min: number;
+  max: number;
+  step: number;                       // Can be fractional
+  unit?: string;                      // Appears next to the live value
+  defaultValue: number;               // Starting value in the simulator
+  targetRange: [number, number];      // Success window checked in real time
+  insight: string;                    // Positive feedback when in range
+  caution: string;                    // Coaching line when outside the range
+}
+```
+
+Live feedback is generated automatically. When the learner drags a slider into the `targetRange`, the simulator shows `insight`; otherwise it highlights `caution` with the distance to the recommended band.
+
+## Adding a new scenario
+
+1. **Create the definition** in [`src/data/scenarios.ts`](../src/data/scenarios.ts).
+   * Choose a unique `id` and reuse the related learning module inside `moduleContext` to keep continuity.
+   * Add both `college` and `professional` persona entries even if the tone only changes slightly.
+   * Define 2–4 `parameters` with realistic ranges and target windows that reflect the skills you want the learner to practice.
+2. **Attach a reward**.
+   * Provide `points` to award on success.
+   * Optionally set `badgeId` to grant a bespoke emblem. To surface the badge in the Reward Center, add a matching entry in [`src/data/rewards.ts`](../src/data/rewards.ts).
+3. **Update supporting copy** if needed.
+   * Reference module lore (e.g., Probability Forest insights) so the scenario feels like a direct extension of the course path.
+4. **Test the experience**.
+   * Run `npm run lint` to ensure type safety.
+   * Launch `npm run dev`, open the Scenario Showcase, and drag sliders to verify the success criteria, reward pulse, and badge unlock flow.
+
+By keeping the content in `scenarios.ts`, new drops stay lightweight—add a new object, adjust optional rewards, and the simulator will automatically present the experience across both personas.

--- a/src/components/ScenarioShowcase.tsx
+++ b/src/components/ScenarioShowcase.tsx
@@ -1,38 +1,19 @@
+import { useMemo, useState } from 'react';
 import { motion } from 'framer-motion';
-import { Audience } from '../types';
+import { scenariosForAudience } from '../data/scenarios';
+import { Audience, ScenarioCompletionPayload, ScenarioDefinition } from '../types';
+import { ScenarioSimulator } from './ScenarioSimulator';
 
 interface ScenarioShowcaseProps {
   focus: Audience;
+  completedScenarioIds: string[];
+  onScenarioComplete: (payload: ScenarioCompletionPayload) => void;
 }
 
-const scenarios: Record<Audience, { title: string; description: string; action: string }[]> = {
-  college: [
-    {
-      title: 'Exam Optimiser',
-      description: 'Use probability weights to schedule revision sprints that match your exam risk profile.',
-      action: 'Deploy a 10-minute plan',
-    },
-    {
-      title: 'Campus Budgeteer',
-      description: 'Track spending vs. savings with interactive ratios before the next tuition bill drops.',
-      action: 'Generate insights',
-    },
-  ],
-  professional: [
-    {
-      title: 'Portfolio Pulse',
-      description: 'Simulate market swings and stress test how your investments react over a quarter.',
-      action: 'Run stress test',
-    },
-    {
-      title: 'Product Launch Odds',
-      description: 'Estimate launch scenarios and expected revenue bands before presenting to leadership.',
-      action: 'Model outcomes',
-    },
-  ],
-};
+export const ScenarioShowcase = ({ focus, completedScenarioIds, onScenarioComplete }: ScenarioShowcaseProps) => {
+  const scenarios = useMemo(() => scenariosForAudience(focus), [focus]);
+  const [activeScenario, setActiveScenario] = useState<ScenarioDefinition | null>(null);
 
-export const ScenarioShowcase = ({ focus }: ScenarioShowcaseProps) => {
   return (
     <section className="bg-white/5 border border-white/10 rounded-3xl px-6 py-6">
       <div className="flex items-center justify-between mb-6">
@@ -43,20 +24,57 @@ export const ScenarioShowcase = ({ focus }: ScenarioShowcaseProps) => {
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        {scenarios[focus].map((scenario) => (
-          <motion.div
-            key={scenario.title}
-            whileHover={{ translateY: -4 }}
-            className="rounded-3xl border border-white/10 bg-white/5 px-5 py-5"
-          >
-            <h4 className="font-display text-xl text-white mb-2">{scenario.title}</h4>
-            <p className="text-sm text-slate-200 leading-relaxed">{scenario.description}</p>
-            <button className="mt-4 inline-flex items-center rounded-full border border-aurora text-aurora px-4 py-2 text-xs uppercase tracking-widest">
-              {scenario.action}
-            </button>
-          </motion.div>
-        ))}
+        {scenarios.map((scenario) => {
+          const persona = scenario.personas[focus];
+          const completed = completedScenarioIds.includes(scenario.id);
+
+          return (
+            <motion.div
+              key={scenario.id}
+              whileHover={{ translateY: -4 }}
+              className="relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 px-5 py-5"
+            >
+              <div className={`absolute inset-0 opacity-40 bg-gradient-to-br ${scenario.accent}`} aria-hidden />
+              <div className="relative">
+                <div className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-slate-950/40 px-3 py-1 text-xs uppercase tracking-widest text-white">
+                  <span>{scenario.icon}</span>
+                  <span>{scenario.moduleContext.name}</span>
+                </div>
+                <h4 className="font-display text-xl text-white mt-3">{scenario.title}</h4>
+                <p className="text-sm text-slate-200 leading-relaxed mt-2">{persona.cardDescription}</p>
+                <p className="mt-3 text-xs uppercase tracking-widest text-slate-200">Objective</p>
+                <p className="text-sm text-slate-100 leading-relaxed">{persona.objective}</p>
+                <button
+                  type="button"
+                  onClick={() => setActiveScenario(scenario)}
+                  className="mt-4 inline-flex items-center rounded-full border border-white/20 bg-slate-950/40 px-4 py-2 text-xs uppercase tracking-widest text-aurora hover:border-aurora hover:text-white"
+                >
+                  {completed ? 'Review your log' : 'Launch simulator'}
+                </button>
+                {completed && (
+                  <span className="mt-3 inline-flex items-center gap-2 rounded-full border border-moss/40 bg-moss/20 px-3 py-1 text-xs font-semibold uppercase tracking-widest text-moss">
+                    Completed
+                  </span>
+                )}
+              </div>
+            </motion.div>
+          );
+        })}
       </div>
+      {activeScenario && (
+        <ScenarioSimulator
+          key={activeScenario.id}
+          open={Boolean(activeScenario)}
+          scenario={activeScenario}
+          focus={focus}
+          completed={completedScenarioIds.includes(activeScenario.id)}
+          onClose={() => setActiveScenario(null)}
+          onObjectiveMet={(payload) => {
+            onScenarioComplete(payload);
+            setActiveScenario(null);
+          }}
+        />
+      )}
     </section>
   );
 };

--- a/src/components/ScenarioSimulator.tsx
+++ b/src/components/ScenarioSimulator.tsx
@@ -1,0 +1,208 @@
+import { useEffect, useMemo, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { Audience, ScenarioCompletionPayload, ScenarioDefinition } from '../types';
+
+interface ScenarioSimulatorProps {
+  scenario: ScenarioDefinition;
+  focus: Audience;
+  open: boolean;
+  completed: boolean;
+  onClose: () => void;
+  onObjectiveMet: (payload: ScenarioCompletionPayload) => void;
+}
+
+const withinTarget = (value: number, [min, max]: [number, number]) => value >= min && value <= max;
+
+const formatValue = (value: number, unit?: string) => {
+  const formatted = Number.isInteger(value) ? value.toFixed(0) : value.toFixed(1);
+  if (!unit) {
+    return formatted;
+  }
+  const trimmed = unit.trim();
+  if (trimmed.startsWith('%')) {
+    const descriptor = trimmed.slice(1).trim();
+    return `${formatted}%${descriptor ? ` ${descriptor}` : ''}`;
+  }
+  return `${formatted} ${trimmed}`;
+};
+
+export const ScenarioSimulator = ({
+  scenario,
+  focus,
+  open,
+  completed,
+  onClose,
+  onObjectiveMet,
+}: ScenarioSimulatorProps) => {
+  const persona = scenario.personas[focus];
+  const [values, setValues] = useState<Record<string, number>>(() => {
+    const entries = scenario.parameters.map((parameter) => [parameter.id, parameter.defaultValue]);
+    return Object.fromEntries(entries);
+  });
+  const [claimed, setClaimed] = useState<boolean>(completed);
+
+  useEffect(() => {
+    setClaimed(completed);
+  }, [completed]);
+
+  useEffect(() => {
+    setValues(() => {
+      const entries = scenario.parameters.map((parameter) => [parameter.id, parameter.defaultValue]);
+      return Object.fromEntries(entries);
+    });
+  }, [scenario]);
+
+  const readiness = useMemo(() => {
+    const met = scenario.parameters.every((parameter) => withinTarget(values[parameter.id], parameter.targetRange));
+    const dialed = scenario.parameters.filter((parameter) => withinTarget(values[parameter.id], parameter.targetRange)).length;
+    const ratio = Math.round((dialed / scenario.parameters.length) * 100);
+    return {
+      met,
+      dialed,
+      ratio,
+    };
+  }, [scenario.parameters, values]);
+
+  const handleClaim = () => {
+    if (!readiness.met || claimed) {
+      return;
+    }
+    onObjectiveMet({
+      scenarioId: scenario.id,
+      reward: scenario.reward,
+    });
+    setClaimed(true);
+  };
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 backdrop-blur"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+        >
+          <motion.div
+            className="w-full max-w-3xl rounded-3xl border border-white/10 bg-slate-950/90 px-6 py-6 shadow-2xl"
+            initial={{ translateY: 32, opacity: 0 }}
+            animate={{ translateY: 0, opacity: 1 }}
+            exit={{ translateY: 32, opacity: 0 }}
+            transition={{ type: 'spring', stiffness: 200, damping: 24 }}
+          >
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <div className={`inline-flex items-center gap-2 rounded-full bg-gradient-to-r ${scenario.accent} px-4 py-1 text-sm text-white`}> 
+                  <span>{scenario.icon}</span>
+                  <span>{scenario.moduleContext.name}</span>
+                </div>
+                <h3 className="mt-4 text-2xl font-display text-white">{scenario.title}</h3>
+                <p className="mt-2 text-sm text-slate-200 leading-relaxed">{persona.narrative}</p>
+              </div>
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs uppercase tracking-widest text-slate-200 hover:border-white/40 hover:text-white"
+              >
+                Close
+              </button>
+            </div>
+
+            <div className="mt-6 grid grid-cols-1 gap-4 md:grid-cols-2">
+              <div className="rounded-2xl border border-white/10 bg-white/5 p-4">
+                <h4 className="text-sm font-semibold text-white uppercase tracking-widest">Forest Insight</h4>
+                <p className="mt-2 text-sm text-slate-200 leading-relaxed">{scenario.moduleContext.insight}</p>
+
+                <h4 className="mt-6 text-sm font-semibold text-white uppercase tracking-widest">Objective</h4>
+                <p className="mt-2 text-sm text-slate-200 leading-relaxed">{persona.objective}</p>
+
+                <h4 className="mt-6 text-sm font-semibold text-white uppercase tracking-widest">Baseline Signals</h4>
+                <ul className="mt-2 space-y-2 text-sm text-slate-200">
+                  {persona.baseline.map((item) => (
+                    <li key={item.label} className="rounded-xl border border-white/10 bg-slate-950/60 px-3 py-2">
+                      <p className="font-semibold text-white">{item.label}</p>
+                      <p>{item.value}</p>
+                      <p className="text-xs text-slate-300">{item.helper}</p>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              <div className="rounded-2xl border border-white/10 bg-white/5 p-4 space-y-4">
+                {scenario.parameters.map((parameter) => {
+                  const value = values[parameter.id];
+                  const inRange = withinTarget(value, parameter.targetRange);
+                  const delta = !inRange
+                    ? value < parameter.targetRange[0]
+                      ? parameter.targetRange[0] - value
+                      : value - parameter.targetRange[1]
+                    : 0;
+                  return (
+                    <div key={parameter.id} className="rounded-xl border border-white/10 bg-slate-950/50 px-3 py-3">
+                      <div className="flex items-center justify-between text-sm text-white">
+                        <p className="font-medium">{parameter.label}</p>
+                        <span className="text-xs uppercase tracking-widest text-slate-300">
+                          {formatValue(value, parameter.unit)}
+                        </span>
+                      </div>
+                      <p className="mt-1 text-xs text-slate-300 leading-relaxed">{parameter.description}</p>
+                      <input
+                        type="range"
+                        min={parameter.min}
+                        max={parameter.max}
+                        step={parameter.step}
+                        value={value}
+                        onChange={(event) => {
+                          const nextValue = Number(event.target.value);
+                          setValues((prev) => ({ ...prev, [parameter.id]: nextValue }));
+                        }}
+                        className="mt-3 w-full accent-aurora"
+                      />
+                      <p className={`mt-2 text-xs ${inRange ? 'text-moss' : 'text-amber-300'}`}>
+                        {inRange
+                          ? parameter.insight
+                          : `${parameter.caution} (${formatValue(delta, parameter.unit)} off target)`}
+                      </p>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div className="mt-6 flex flex-col gap-4 rounded-2xl border border-white/10 bg-white/5 p-4 md:flex-row md:items-center md:justify-between">
+              <div>
+                <p className="text-sm font-semibold uppercase tracking-widest text-white">Success Criteria</p>
+                <p className="mt-2 text-sm text-slate-200 leading-relaxed">{scenario.success.summary}</p>
+                <ul className="mt-2 list-disc pl-5 text-xs text-slate-300 space-y-1">
+                  {scenario.success.checkpoints.map((checkpoint) => (
+                    <li key={checkpoint}>{checkpoint}</li>
+                  ))}
+                </ul>
+              </div>
+              <div className="rounded-2xl border border-white/10 bg-slate-950/60 px-4 py-4 text-center">
+                <p className="text-xs uppercase tracking-widest text-slate-300">Readiness</p>
+                <p className="mt-2 text-3xl font-display text-white">{readiness.ratio}%</p>
+                <p className="text-xs text-slate-300">Targets dialled in: {readiness.dialed}/{scenario.parameters.length}</p>
+                <button
+                  type="button"
+                  onClick={handleClaim}
+                  disabled={!readiness.met || claimed}
+                  className={`mt-4 inline-flex items-center justify-center rounded-full px-4 py-2 text-xs uppercase tracking-widest transition-all ${
+                    readiness.met && !claimed
+                      ? 'bg-aurora/90 text-slate-950 hover:bg-aurora'
+                      : 'border border-white/10 bg-white/5 text-slate-300 cursor-not-allowed'
+                  }`}
+                >
+                  {claimed ? 'Objective logged' : readiness.met ? 'Log scenario & claim' : 'Tune targets to unlock'}
+                </button>
+                <p className="mt-2 text-xs text-slate-400">
+                  Reward: +{scenario.reward.points} pts{scenario.reward.badgeId ? ` · Badge: ${scenario.reward.badgeId}` : ''}
+                </p>
+              </div>
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+};

--- a/src/data/rewards.ts
+++ b/src/data/rewards.ts
@@ -19,4 +19,16 @@ export const rewardBadges: RewardBadge[] = [
     description: 'Complete all checkpoints on the Progress Map.',
     threshold: 4,
   },
+  {
+    id: 'probability-forest-strategist',
+    name: 'Probability Forest Strategist',
+    description: 'Complete the Risk Sprint scenario with optimal pacing.',
+    threshold: 1,
+  },
+  {
+    id: 'probability-forest-guardian',
+    name: 'Forest Guardian',
+    description: 'Stabilise every lever inside the Safety Net scenario.',
+    threshold: 1,
+  },
 ];

--- a/src/data/scenarios.ts
+++ b/src/data/scenarios.ts
@@ -1,0 +1,183 @@
+import { Audience, ScenarioDefinition } from '../types';
+
+export const scenarioLibrary: ScenarioDefinition[] = [
+  {
+    id: 'probability-forest-risk-sprint',
+    title: 'Probability Forest: Risk Sprint',
+    icon: '🌲',
+    accent: 'from-emerald-400/90 to-aurora/70',
+    moduleContext: {
+      id: 'probability-forest',
+      name: 'Probability Forest',
+      insight:
+        'Use distribution sense from the Probability Forest trail to keep your decisions balanced under pressure.',
+    },
+    personas: {
+      college: {
+        cardDescription: 'Turn exam uncertainty into a confident 48-hour action sprint.',
+        narrative:
+          'Your Probability Forest drills revealed which lecture branches hide the trickiest questions. You have two nights before the calculus final and need to distribute your energy wisely.',
+        objective: 'Dial in a revision rhythm that keeps fatigue low while covering the riskiest units.',
+        baseline: [
+          { label: 'Exam weight', value: '35% of course grade', helper: 'Probability Forest warns against overcommitting to low-impact chapters.' },
+          { label: 'Focus chapters', value: 'Series, Integrals, Random Walks', helper: 'Each carries a 0.3 probability of appearing as a boss-level prompt.' },
+        ],
+      },
+      professional: {
+        cardDescription: 'Map uncertainty before presenting your product-readiness score.',
+        narrative:
+          'The Probability Forest dashboard exposed the launch path nodes that fail most often. Leadership wants a go/no-go report in 48 hours and expects evidence you mitigated the riskiest leaf nodes.',
+        objective: 'Balance deep dives with rehearsal time so the launch review feels confident and data-backed.',
+        baseline: [
+          { label: 'Launch risk budget', value: '25% tolerance', helper: 'Anything above that threshold triggers executive escalations.' },
+          { label: 'Critical tracks', value: 'Infra, Adoption, Support', helper: 'Each branch triggered at least two red flags in the forest replay.' },
+        ],
+      },
+    },
+    parameters: [
+      {
+        id: 'focusAllocation',
+        label: 'High-risk focus allocation',
+        description: 'Percent of time dedicated to the nodes flagged as red in your Probability Forest map.',
+        min: 20,
+        max: 80,
+        step: 1,
+        unit: '%',
+        defaultValue: 55,
+        targetRange: [48, 60],
+        insight: 'Nice! That coverage keeps the riskiest paths under control without starving other work.',
+        caution: 'If you drift away from ~55% coverage, surprise nodes may slip into the review.',
+      },
+      {
+        id: 'deepWorkHours',
+        label: 'Deep work block',
+        description: 'Hours reserved for uninterrupted analysis or revision before the decision point.',
+        min: 2,
+        max: 10,
+        step: 0.5,
+        unit: 'hrs',
+        defaultValue: 5,
+        targetRange: [4.5, 6.5],
+        insight: 'Great pacing—your Probability Forest simulations show accuracy spikes at this cadence.',
+        caution: 'Too little and you miss pattern recognition; too much and fatigue drags performance.',
+      },
+      {
+        id: 'confidencePulse',
+        label: 'Confidence pulse check',
+        description: 'Self-reported confidence after dry runs. Keep it grounded to avoid blind spots.',
+        min: 40,
+        max: 100,
+        step: 1,
+        unit: '%',
+        defaultValue: 72,
+        targetRange: [68, 80],
+        insight: 'Balanced confidence—evidence-led without drifting into overconfidence.',
+        caution: 'Confidence outside the sweet spot suggests either anxiety spikes or unchecked optimism.',
+      },
+    ],
+    success: {
+      summary: 'Stabilise the hot zones, stay fresh, and walk into the review prepared.',
+      checkpoints: [
+        'Allocate at least half your sprint to red-flag content.',
+        'Stack 5±1 hours of protected focus time.',
+        'Keep self-reported confidence between 68% and 80%.',
+      ],
+    },
+    reward: {
+      points: 80,
+      badgeId: 'probability-forest-strategist',
+      celebration: 'Risk sprint aligned! Probability Forest applauds your pacing. 🌲',
+    },
+  },
+  {
+    id: 'probability-forest-safety-net',
+    title: 'Probability Forest: Safety Net Planner',
+    icon: '🛡️',
+    accent: 'from-sky-400/90 to-violet-500/70',
+    moduleContext: {
+      id: 'probability-forest',
+      name: 'Probability Forest',
+      insight: 'Pull variance intuition from Probability Forest to cushion against unlucky branches.',
+    },
+    personas: {
+      college: {
+        cardDescription: 'Build a backup plan for project delivery week when teammates go dark.',
+        narrative:
+          'During the Probability Forest quest you logged how group projects implode when contributors vanish. Finals week is here and two teammates are juggling internships.',
+        objective: 'Keep your project delivery timeline safe even if a teammate misses their milestone.',
+        baseline: [
+          { label: 'Team reliability', value: '0.6 average attendance', helper: 'Probability Forest predicted at least one missed stand-up this week.' },
+          { label: 'Buffer before deadline', value: '3 days', helper: 'Use the buffer to absorb variance without rushing QA.' },
+        ],
+      },
+      professional: {
+        cardDescription: 'Design a contingency cushion for a quarterly portfolio review.',
+        narrative:
+          'The Probability Forest replay flagged the cash runway nodes most exposed to vendor delays. Finance needs a contingency briefing before presenting to the board.',
+        objective: 'Layer safeguards so the portfolio withstands a moderate supply chain shock.',
+        baseline: [
+          { label: 'Portfolio volatility', value: 'σ = 4.5%', helper: 'Higher than target, meaning reserves matter more this quarter.' },
+          { label: 'Vendor dependency', value: '3 critical suppliers', helper: 'Each supplier has a 0.25 chance of slippage this month.' },
+        ],
+      },
+    },
+    parameters: [
+      {
+        id: 'reserveRatio',
+        label: 'Safety reserve ratio',
+        description: 'Percent of total effort or budget set aside purely as contingency.',
+        min: 5,
+        max: 40,
+        step: 1,
+        unit: '%',
+        defaultValue: 18,
+        targetRange: [16, 24],
+        insight: 'Solid! That reserve keeps the path resilient without stalling progress.',
+        caution: 'Falling outside this range either risks burnout or locks too much in idle reserves.',
+      },
+      {
+        id: 'communicationCadence',
+        label: 'Checkpoint cadence',
+        description: 'Frequency of syncs to surface blockers before they cascade.',
+        min: 1,
+        max: 7,
+        step: 0.5,
+        unit: 'days',
+        defaultValue: 2.5,
+        targetRange: [2, 3],
+        insight: 'Rhythm locked! Momentum stays high while still intercepting risky branches.',
+        caution: 'Cadence drift either overwhelms the team or leaves blind spots between check-ins.',
+      },
+      {
+        id: 'escalationThreshold',
+        label: 'Escalation threshold',
+        description: 'Deviation level that triggers you to deploy the reserve plan.',
+        min: 5,
+        max: 30,
+        step: 1,
+        unit: '% variance',
+        defaultValue: 15,
+        targetRange: [12, 18],
+        insight: 'Smart trigger—Probability Forest heuristics say escalate before 18% deviation.',
+        caution: 'If you wait too long, variance compounds; escalate too early and morale dips.',
+      },
+    ],
+    success: {
+      summary: 'A resilient plan keeps timelines and financial exposure within guardrails.',
+      checkpoints: [
+        'Hold 16–24% of effort/budget in reserve.',
+        'Sync every ~2–3 days to detect drift early.',
+        'Escalate when variance crosses 12–18%.',
+      ],
+    },
+    reward: {
+      points: 95,
+      badgeId: 'probability-forest-guardian',
+      celebration: 'Safety net secured! Probability Forest signals a stable path forward. 🛡️',
+    },
+  },
+];
+
+export function scenariosForAudience(focus: Audience) {
+  return scenarioLibrary.filter((scenario) => Boolean(scenario.personas[focus]));
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,3 +61,54 @@ export interface ProgressSnapshot {
   totalCount: number;
   completionRate: number;
 }
+
+export interface ScenarioParameter {
+  id: string;
+  label: string;
+  description: string;
+  min: number;
+  max: number;
+  step: number;
+  unit?: string;
+  defaultValue: number;
+  targetRange: [number, number];
+  insight: string;
+  caution: string;
+}
+
+export interface ScenarioPersonaContent {
+  cardDescription: string;
+  narrative: string;
+  objective: string;
+  baseline: { label: string; value: string; helper: string }[];
+}
+
+export interface ScenarioReward {
+  points: number;
+  badgeId?: string;
+  celebration: string;
+}
+
+export interface ScenarioDefinition {
+  id: string;
+  title: string;
+  icon: string;
+  accent: string;
+  moduleContext: {
+    id: string;
+    name: string;
+    insight: string;
+  };
+  personas: Record<Audience, ScenarioPersonaContent>;
+  parameters: ScenarioParameter[];
+  success: {
+    summary: string;
+    checkpoints: string[];
+  };
+  reward: ScenarioReward;
+}
+
+export interface ScenarioCompletionPayload {
+  scenarioId: string;
+  reward: ScenarioReward;
+}


### PR DESCRIPTION
## Summary
- add structured scenario definitions and persona copy for Probability Forest scenarios
- expand the scenario showcase with an interactive simulator tied into the reward loop
- document the scenario schema so new drops stay lightweight

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd75ab4330832fab3fa8f8d6cdb2a0