### PR TITLE
Fix Firebase onboarding sync and daily challenge completion

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,48 @@
+# Cloud Sync Setup
+
+MathQuest now syncs player state with Firebase. To enable cloud features, configure Firebase and provide the environment variables described below.
+
+## Firebase Project Requirements
+
+1. Create a Firebase project (https://console.firebase.google.com/) if you do not already have one.
+2. Enable the following services:
+   - **Authentication** → enable **Anonymous** sign-in (or your preferred provider) so the app can bootstrap a user session.
+   - **Cloud Firestore** in production mode (rules should guard the `profiles`, `dailyRuns`, and `leaderboards` collections).
+3. From your Firebase project settings, register a new Web app and copy the configuration values.
+
+## Environment Variables
+
+Create a `.env` file (or `.env.local` when using Vite) at the project root with the Firebase settings:
+
+```
+VITE_FIREBASE_API_KEY=your-api-key
+VITE_FIREBASE_AUTH_DOMAIN=your-project.firebaseapp.com
+VITE_FIREBASE_PROJECT_ID=your-project-id
+VITE_FIREBASE_STORAGE_BUCKET=your-project.appspot.com
+VITE_FIREBASE_MESSAGING_SENDER_ID=your-messaging-sender-id
+VITE_FIREBASE_APP_ID=your-app-id
+```
+
+Restart the dev server after adding these variables.
+
+## Firestore Data Model
+
+The app expects the following collections:
+
+- `profiles/{uid}` – stores the player profile, XP totals, and unlocked modules.
+- `dailyRuns/{uid}/runs/{date}` – tracks daily challenge completions and uses Firestore server timestamps for streak calculations.
+- `leaderboards/weekly/entries/{uid}` – caches weekly leaderboard entries so the UI can display ranked XP totals.
+
+Writes to `profiles` and `leaderboards/weekly` occur in a single batch to keep XP in sync after each reward distribution.
+
+## Authentication Providers
+
+Anonymous authentication is enabled by default through the new `useCloudProfile` hook. You can switch to other providers (Google, email/password, etc.) by enabling them in Firebase Auth and updating `ensureAnonymousUser` in `src/services/firebase.ts` to perform the relevant sign-in flow.
+
+## Local Development
+
+1. Install dependencies: `npm install`
+2. Provide the Firebase environment variables described above.
+3. Start the dev server: `npm run dev`
+
+Cloud sync automatically falls back to the existing local cache until Firebase responds, so you can continue developing offline if needed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "classnames": "^2.5.1",
+        "firebase": "^12.3.0",
         "framer-motion": "^12.23.16",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
@@ -762,6 +763,645 @@
         "node": ">=18"
       }
     },
+    "node_modules/@firebase/ai": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.3.0.tgz",
+      "integrity": "sha512-rVZgf4FszXPSFVIeWLE8ruLU2JDmPXw4XgghcC0x/lK9veGJIyu+DvyumjreVhW/RwD3E5cNPWxQunzylhf/6w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.3",
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics": {
+      "version": "0.10.18",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.18.tgz",
+      "integrity": "sha512-iN7IgLvM06iFk8BeFoWqvVpRFW3Z70f+Qe2PfCJ7vPIgLPjHXDE774DhCT5Y2/ZU/ZbXPDPD60x/XPWEoZLNdg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/installations": "0.6.19",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-compat": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.24.tgz",
+      "integrity": "sha512-jE+kJnPG86XSqGQGhXXYt1tpTbCTED8OQJ/PQ90SEw14CuxRxx/H+lFbWA1rlFtFSsTCptAJtgyRBwr/f00vsw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/analytics": "0.10.18",
+        "@firebase/analytics-types": "0.8.3",
+        "@firebase/component": "0.7.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-types": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.3.tgz",
+      "integrity": "sha512-VrIp/d8iq2g501qO46uGz3hjbDb8xzYMrbu8Tp0ovzIzrvJZ2fvmj649gTjge/b7cCCcjT0H37g1gVtlNhnkbg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.3.tgz",
+      "integrity": "sha512-by1leTfZkwGycPKRWpc+p5/IhpnOj8zaScVi4RRm9fMoFYS3IE87Wzx1Yf/ruVYowXOEuLqYY3VmJw5tU3+0Bg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/app-check": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.11.0.tgz",
+      "integrity": "sha512-XAvALQayUMBJo58U/rxW02IhsesaxxfWVmVkauZvGEz3vOAjMEQnzFlyblqkc2iAaO82uJ2ZVyZv9XzPfxjJ6w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-compat": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.4.0.tgz",
+      "integrity": "sha512-UfK2Q8RJNjYM/8MFORltZRG9lJj11k0nW84rrffiKvcJxLf1jf6IEjCIkCamykHE73C6BwqhVfhIBs69GXQV0g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check": "0.11.0",
+        "@firebase/app-check-types": "0.5.3",
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-interop-types": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.3.tgz",
+      "integrity": "sha512-gAlxfPLT2j8bTI/qfe3ahl2I2YcBQ8cFIBdhAQA4I2f3TndcO+22YizyGYuttLHPQEpWkhmpFW60VCFEPg4g5A==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-check-types": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.3.tgz",
+      "integrity": "sha512-hyl5rKSj0QmwPdsAxrI5x1otDlByQ7bvNvVt8G/XPO2CSwE++rmSVf3VEhaeOR4J8ZFaF0Z0NDSmLejPweZ3ng==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-compat": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.3.tgz",
+      "integrity": "sha512-rRK9YOvgsAU/+edjgubL1q1FyCMjBZZs+fAWtD36tklawkh6WZV07sNLVSceuni+a21oby6xoad+3R8dfztOrA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app": "0.14.3",
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/app-types": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
+      "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/auth": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.11.0.tgz",
+      "integrity": "sha512-5j7+ua93X+IRcJ1oMDTClTo85l7Xe40WSkoJ+shzPrX7OISlVWLdE1mKC57PSD+/LfAbdhJmvKixINBw2ESK6w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@react-native-async-storage/async-storage": "^1.18.1"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/auth-compat": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.6.0.tgz",
+      "integrity": "sha512-J0lGSxXlG/lYVi45wbpPhcWiWUMXevY4fvLZsN1GHh+po7TZVng+figdHBVhFheaiipU8HZyc7ljw1jNojM2nw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth": "1.11.0",
+        "@firebase/auth-types": "0.13.0",
+        "@firebase/component": "0.7.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/auth-interop-types": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.4.tgz",
+      "integrity": "sha512-JPgcXKCuO+CWqGDnigBtvo09HeBs5u/Ktc2GaFj2m01hLarbxthLNm7Fk8iOP1aqAtXV+fnnGj7U28xmk7IwVA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/auth-types": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.13.0.tgz",
+      "integrity": "sha512-S/PuIjni0AQRLF+l9ck0YpsMOdE8GO2KU6ubmBB7P+7TJUCQDa3R1dlgYm9UzGbbePMZsp0xzB93f2b/CgxMOg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/component": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.0.tgz",
+      "integrity": "sha512-wR9En2A+WESUHexjmRHkqtaVH94WLNKt6rmeqZhSLBybg4Wyf0Umk04SZsS6sBq4102ZsDBFwoqMqJYj2IoDSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/data-connect": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.3.11.tgz",
+      "integrity": "sha512-G258eLzAD6im9Bsw+Qm1Z+P4x0PGNQ45yeUuuqe5M9B1rn0RJvvsQCRHXgE52Z+n9+WX1OJd/crcuunvOGc7Vw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth-interop-types": "0.2.4",
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/database": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.0.tgz",
+      "integrity": "sha512-gM6MJFae3pTyNLoc9VcJNuaUDej0ctdjn3cVtILo3D5lpp0dmUHHLFN/pUKe7ImyeB1KAvRlEYxvIHNF04Filg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.3",
+        "@firebase/auth-interop-types": "0.2.4",
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "faye-websocket": "0.11.4",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-compat": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.0.tgz",
+      "integrity": "sha512-8nYc43RqxScsePVd1qe1xxvWNf0OBnbwHxmXJ7MHSuuTVYFO3eLyLW3PiCKJ9fHnmIz4p4LbieXwz+qtr9PZDg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/database": "1.1.0",
+        "@firebase/database-types": "1.0.16",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-types": {
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.16.tgz",
+      "integrity": "sha512-xkQLQfU5De7+SPhEGAXFBnDryUWhhlFXelEg2YeZOQMCdoe7dL64DDAd77SQsR+6uoXIZY5MB4y/inCs4GTfcw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-types": "0.9.3",
+        "@firebase/util": "1.13.0"
+      }
+    },
+    "node_modules/@firebase/firestore": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.9.2.tgz",
+      "integrity": "sha512-iuA5+nVr/IV/Thm0Luoqf2mERUvK9g791FZpUJV1ZGXO6RL2/i/WFJUj5ZTVXy5pRjpWYO+ZzPcReNrlilmztA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "@firebase/webchannel-wrapper": "1.0.5",
+        "@grpc/grpc-js": "~1.9.0",
+        "@grpc/proto-loader": "^0.7.8",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-compat": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.4.2.tgz",
+      "integrity": "sha512-cy7ov6SpFBx+PHwFdOOjbI7kH00uNKmIFurAn560WiPCZXy9EMnil1SOG7VF4hHZKdenC+AHtL4r3fNpirpm0w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/firestore": "4.9.2",
+        "@firebase/firestore-types": "3.0.3",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-types": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.3.tgz",
+      "integrity": "sha512-hD2jGdiWRxB/eZWF89xcK9gF8wvENDJkzpVFb4aGkzfEaKxVRD1kjz1t1Wj8VZEp2LCB53Yx1zD8mrhQu87R6Q==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/functions": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.13.1.tgz",
+      "integrity": "sha512-sUeWSb0rw5T+6wuV2o9XNmh9yHxjFI9zVGFnjFi+n7drTEWpl7ZTz1nROgGrSu472r+LAaj+2YaSicD4R8wfbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.3",
+        "@firebase/auth-interop-types": "0.2.4",
+        "@firebase/component": "0.7.0",
+        "@firebase/messaging-interop-types": "0.2.3",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-compat": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.4.1.tgz",
+      "integrity": "sha512-AxxUBXKuPrWaVNQ8o1cG1GaCAtXT8a0eaTDfqgS5VsRYLAR0ALcfqDLwo/QyijZj1w8Qf8n3Qrfy/+Im245hOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/functions": "0.13.1",
+        "@firebase/functions-types": "0.6.3",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-types": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.3.tgz",
+      "integrity": "sha512-EZoDKQLUHFKNx6VLipQwrSMh01A1SaL3Wg6Hpi//x6/fJ6Ee4hrAeswK99I5Ht8roiniKHw4iO0B1Oxj5I4plg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/installations": {
+      "version": "0.6.19",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.19.tgz",
+      "integrity": "sha512-nGDmiwKLI1lerhwfwSHvMR9RZuIH5/8E3kgUWnVRqqL7kGVSktjLTWEMva7oh5yxQ3zXfIlIwJwMcaM5bK5j8Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/util": "1.13.0",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-compat": {
+      "version": "0.2.19",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.19.tgz",
+      "integrity": "sha512-khfzIY3EI5LePePo7vT19/VEIH1E3iYsHknI/6ek9T8QCozAZshWT9CjlwOzZrKvTHMeNcbpo/VSOSIWDSjWdQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/installations": "0.6.19",
+        "@firebase/installations-types": "0.5.3",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-types": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.3.tgz",
+      "integrity": "sha512-2FJI7gkLqIE0iYsNQ1P751lO3hER+Umykel+TkLwHj6plzWVxqvfclPUZhcKFVQObqloEBTmpi2Ozn7EkCABAA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/logger": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.5.0.tgz",
+      "integrity": "sha512-cGskaAvkrnh42b3BA3doDWeBmuHFO/Mx5A83rbRDYakPjO9bJtRL3dX7javzc2Rr/JHZf4HlterTW2lUkfeN4g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/messaging": {
+      "version": "0.12.23",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.23.tgz",
+      "integrity": "sha512-cfuzv47XxqW4HH/OcR5rM+AlQd1xL/VhuaeW/wzMW1LFrsFcTn0GND/hak1vkQc2th8UisBcrkVcQAnOnKwYxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/installations": "0.6.19",
+        "@firebase/messaging-interop-types": "0.2.3",
+        "@firebase/util": "1.13.0",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-compat": {
+      "version": "0.2.23",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.23.tgz",
+      "integrity": "sha512-SN857v/kBUvlQ9X/UjAqBoQ2FEaL1ZozpnmL1ByTe57iXkmnVVFm9KqAsTfmf+OEwWI4kJJe9NObtN/w22lUgg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/messaging": "0.12.23",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-interop-types": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.3.tgz",
+      "integrity": "sha512-xfzFaJpzcmtDjycpDeCUj0Ge10ATFi/VHVIvEEjDNc3hodVBQADZ7BWQU7CuFpjSHE+eLuBI13z5F/9xOoGX8Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/performance": {
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.9.tgz",
+      "integrity": "sha512-UzybENl1EdM2I1sjYm74xGt/0JzRnU/0VmfMAKo2LSpHJzaj77FCLZXmYQ4oOuE+Pxtt8Wy2BVJEENiZkaZAzQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/installations": "0.6.19",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0",
+        "web-vitals": "^4.2.4"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-compat": {
+      "version": "0.2.22",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.22.tgz",
+      "integrity": "sha512-xLKxaSAl/FVi10wDX/CHIYEUP13jXUjinL+UaNXT9ByIvxII5Ne5150mx6IgM8G6Q3V+sPiw9C8/kygkyHUVxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/performance": "0.7.9",
+        "@firebase/performance-types": "0.2.3",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-types": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.3.tgz",
+      "integrity": "sha512-IgkyTz6QZVPAq8GSkLYJvwSLr3LS9+V6vNPQr0x4YozZJiLF5jYixj0amDtATf1X0EtYHqoPO48a9ija8GocxQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/remote-config": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.7.0.tgz",
+      "integrity": "sha512-dX95X6WlW7QlgNd7aaGdjAIZUiQkgWgNS+aKNu4Wv92H1T8Ue/NDUjZHd9xb8fHxLXIHNZeco9/qbZzr500MjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/installations": "0.6.19",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-compat": {
+      "version": "0.2.20",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.20.tgz",
+      "integrity": "sha512-P/ULS9vU35EL9maG7xp66uljkZgcPMQOxLj3Zx2F289baTKSInE6+YIkgHEi1TwHoddC/AFePXPpshPlEFkbgg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/logger": "0.5.0",
+        "@firebase/remote-config": "0.7.0",
+        "@firebase/remote-config-types": "0.5.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-types": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.5.0.tgz",
+      "integrity": "sha512-vI3bqLoF14L/GchtgayMiFpZJF+Ao3uR8WCde0XpYNkSokDpAKca2DxvcfeZv7lZUqkUwQPL2wD83d3vQ4vvrg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/storage": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.14.0.tgz",
+      "integrity": "sha512-xWWbb15o6/pWEw8H01UQ1dC5U3rf8QTAzOChYyCpafV6Xki7KVp3Yaw2nSklUwHEziSWE9KoZJS7iYeyqWnYFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-compat": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.4.0.tgz",
+      "integrity": "sha512-vDzhgGczr1OfcOy285YAPur5pWDEvD67w4thyeCUh6Ys0izN9fNYtA1MJERmNBfqjqu0lg0FM5GLbw0Il21M+g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.0",
+        "@firebase/storage": "0.14.0",
+        "@firebase/storage-types": "0.8.3",
+        "@firebase/util": "1.13.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-types": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.3.tgz",
+      "integrity": "sha512-+Muk7g9uwngTpd8xn9OdF/D48uiQ7I1Fae7ULsWPuKoCH3HU7bfFPhxtJYzyhjdniowhuDpQcfPmuNRAqZEfvg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/util": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.13.0.tgz",
+      "integrity": "sha512-0AZUyYUfpMNcztR5l09izHwXkZpghLgCUaAGjtMwXnCg3bj4ml5VgiwqOMOxJ+Nw4qN/zJAaOQBcJ7KGkWStqQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/webchannel-wrapper": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.5.tgz",
+      "integrity": "sha512-+uGNN7rkfn41HLO0vekTFhTxk61eKa8mTpRGLO0QSqlQdKvIoGAvLp3ppdVIWbTGYJWM6Kp0iN+PjMIOcnVqTw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.9.15",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.15.tgz",
+      "integrity": "sha512-nqE7Hc0AzI+euzUwDAy0aY5hCp10r734gMGRdU+qOPX0XSceI2ULrcXB5U2xSc5VkWwalCj4M7GzCAygZl2KoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.8",
+        "@types/node": ">=12.12.47"
+      },
+      "engines": {
+        "node": "^8.13.0 || >=10.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -878,6 +1518,70 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.35",
@@ -1236,7 +1940,6 @@
       "version": "24.5.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.5.2.tgz",
       "integrity": "sha512-FYxk1I7wPv3K2XBaoyH2cTnocQEu8AOZ60hPbsyukMPLv5/5qr7V1i8PLHdl6Zf87I+xZXFvPCXYjiTFq+YSDQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.12.0"
@@ -1550,11 +2253,97 @@
       "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
       "license": "MIT"
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -1567,7 +2356,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
@@ -1721,7 +2509,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -1767,6 +2554,18 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1796,6 +2595,42 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/firebase": {
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.3.0.tgz",
+      "integrity": "sha512-/JVja0IDO8zPETGv4TvvBwo7RwcQFz+RQ3JBETNtUSeqsDdI9G7fhRTkCy1sPKnLzW0xpm/kL8GOj6ncndTT3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/ai": "2.3.0",
+        "@firebase/analytics": "0.10.18",
+        "@firebase/analytics-compat": "0.2.24",
+        "@firebase/app": "0.14.3",
+        "@firebase/app-check": "0.11.0",
+        "@firebase/app-check-compat": "0.4.0",
+        "@firebase/app-compat": "0.5.3",
+        "@firebase/app-types": "0.9.3",
+        "@firebase/auth": "1.11.0",
+        "@firebase/auth-compat": "0.6.0",
+        "@firebase/data-connect": "0.3.11",
+        "@firebase/database": "1.1.0",
+        "@firebase/database-compat": "2.1.0",
+        "@firebase/firestore": "4.9.2",
+        "@firebase/firestore-compat": "0.4.2",
+        "@firebase/functions": "0.13.1",
+        "@firebase/functions-compat": "0.4.1",
+        "@firebase/installations": "0.6.19",
+        "@firebase/installations-compat": "0.2.19",
+        "@firebase/messaging": "0.12.23",
+        "@firebase/messaging-compat": "0.2.23",
+        "@firebase/performance": "0.7.9",
+        "@firebase/performance-compat": "0.2.22",
+        "@firebase/remote-config": "0.7.0",
+        "@firebase/remote-config-compat": "0.2.20",
+        "@firebase/storage": "0.14.0",
+        "@firebase/storage-compat": "0.4.0",
+        "@firebase/util": "1.13.0"
       }
     },
     "node_modules/foreground-child": {
@@ -1891,6 +2726,15 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/glob": {
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
@@ -1938,6 +2782,18 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/http-parser-js": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
+      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
+      "license": "MIT"
+    },
+    "node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+      "license": "ISC"
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -1981,7 +2837,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -2092,6 +2947,18 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -2523,6 +3390,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -2609,6 +3500,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -2707,6 +3607,26 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.26.0",
@@ -3032,7 +3952,6 @@
       "version": "7.12.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.12.0.tgz",
       "integrity": "sha512-goOacqME2GYyOZZfb5Lgtu+1IDmAlAEu5xnD3+xTzS10hT0vzpf0SPjkXwAw9Jm+4n/mQGDP3LO8CPbYROeBfQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -3146,6 +4065,35 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/web-vitals": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
+      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/websocket-driver": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/which": {
@@ -3262,6 +4210,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -3280,6 +4237,74 @@
       },
       "engines": {
         "node": ">= 14.6"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "classnames": "^2.5.1",
+    "firebase": "^12.3.0",
     "framer-motion": "^12.23.16",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"

--- a/src/components/DailyChallengeRunner.tsx
+++ b/src/components/DailyChallengeRunner.tsx
@@ -1,0 +1,268 @@
+import { AnimatePresence, motion } from 'framer-motion';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  DailyChallenge,
+  DailyChallengePrompt,
+  DailyChallengeRunResult,
+  DailyChallengeRunSummary,
+} from '../types';
+
+interface DailyChallengeRunnerProps {
+  challenge: DailyChallenge | null;
+  onClose: () => void;
+  onComplete: (challenge: DailyChallenge, summary: DailyChallengeRunSummary) => void;
+}
+
+const formatTime = (value: number) => {
+  const minutes = Math.floor(value / 60)
+    .toString()
+    .padStart(2, '0');
+  const seconds = Math.floor(value % 60)
+    .toString()
+    .padStart(2, '0');
+  return `${minutes}:${seconds}`;
+};
+
+export const DailyChallengeRunner = ({ challenge, onClose, onComplete }: DailyChallengeRunnerProps) => {
+  const prompts = useMemo<DailyChallengePrompt[]>(() => {
+    if (!challenge) return [];
+    if (challenge.prompts && challenge.prompts.length > 0) {
+      return challenge.prompts;
+    }
+
+    return challenge.tasks.map((task, index) => ({
+      id: `${challenge.id}-${index}`,
+      question: task,
+      choices: ['Completed', 'Need more time'],
+      correctIndex: 0,
+    }));
+  }, [challenge]);
+
+  const totalSeconds = (challenge?.timeLimitMinutes ?? 0) * 60;
+
+  const [timeRemaining, setTimeRemaining] = useState(totalSeconds);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [results, setResults] = useState<DailyChallengeRunResult[]>([]);
+  const [combo, setCombo] = useState(0);
+  const [selectedChoice, setSelectedChoice] = useState<number | null>(null);
+  const [showFeedback, setShowFeedback] = useState(false);
+  const [hasFinished, setHasFinished] = useState(false);
+
+  useEffect(() => {
+    if (!challenge) return;
+    setTimeRemaining(challenge.timeLimitMinutes * 60);
+    setCurrentIndex(0);
+    setResults([]);
+    setCombo(0);
+    setSelectedChoice(null);
+    setShowFeedback(false);
+    setHasFinished(false);
+  }, [challenge]);
+
+  const finalizeRun = useCallback(
+    (finalResults: DailyChallengeRunResult[], completed: boolean) => {
+      if (!challenge || hasFinished) return;
+
+      const solved = finalResults.length;
+      const correct = finalResults.filter((item) => item.correct).length;
+      let bestCombo = 0;
+      let streak = 0;
+      finalResults.forEach((item) => {
+        if (item.correct) {
+          streak += 1;
+          bestCombo = Math.max(bestCombo, streak);
+        } else {
+          streak = 0;
+        }
+      });
+      const allSolved = finalResults.length === prompts.length;
+
+      const summary: DailyChallengeRunSummary = {
+        challengeId: challenge.id,
+        solved,
+        correct,
+        accuracy: solved === 0 ? 0 : Math.round((correct / solved) * 100),
+        bestCombo,
+        completed: completed && allSolved,
+        allSolved,
+        timeElapsedSeconds: Math.max(0, challenge.timeLimitMinutes * 60 - timeRemaining),
+        results: finalResults,
+      };
+
+      setHasFinished(true);
+      onComplete(challenge, summary);
+      onClose();
+    },
+    [challenge, hasFinished, onClose, onComplete, prompts.length, timeRemaining]
+  );
+
+  useEffect(() => {
+    if (!challenge || hasFinished) return;
+    if (timeRemaining <= 0) {
+      finalizeRun(results, false);
+      return;
+    }
+
+    const interval = window.setInterval(() => {
+      setTimeRemaining((prev) => (prev > 0 ? prev - 1 : 0));
+    }, 1000);
+
+    return () => window.clearInterval(interval);
+  }, [challenge, finalizeRun, hasFinished, results, timeRemaining]);
+
+  const handleSelect = (choiceIndex: number) => {
+    if (!challenge) return;
+    if (selectedChoice !== null) return;
+
+    const prompt = prompts[currentIndex];
+    if (!prompt) return;
+
+    const correct = choiceIndex === prompt.correctIndex;
+    const nextResult: DailyChallengeRunResult = { promptId: prompt.id, correct };
+
+    setResults((prev) => [...prev, nextResult]);
+    setCombo((prev) => (correct ? prev + 1 : 0));
+    setSelectedChoice(choiceIndex);
+    setShowFeedback(true);
+  };
+
+  const handleNext = () => {
+    if (currentIndex >= prompts.length - 1) {
+      finalizeRun(results, true);
+      return;
+    }
+
+    setCurrentIndex((prev) => prev + 1);
+    setSelectedChoice(null);
+    setShowFeedback(false);
+  };
+
+  const answeredCount = results.length;
+  const accuracy = answeredCount
+    ? Math.round((results.filter((result) => result.correct).length / answeredCount) * 100)
+    : 0;
+  const currentPrompt = prompts[currentIndex];
+  const progress = prompts.length === 0 ? 0 : Math.min(100, (answeredCount / prompts.length) * 100);
+  const lastResult = results[results.length - 1];
+  const showHint = showFeedback && lastResult && !lastResult.correct && currentPrompt?.hint;
+
+  return (
+    <AnimatePresence>
+      {challenge && (
+        <motion.div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-midnight/80 backdrop-blur"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+        >
+          <motion.div
+            initial={{ opacity: 0, y: 40 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: 40 }}
+            transition={{ type: 'spring', stiffness: 160, damping: 18 }}
+            className="relative w-full max-w-2xl rounded-3xl border border-white/10 bg-midnight/90 p-8 text-white shadow-glow"
+          >
+            <header className="flex flex-col gap-4 border-b border-white/10 pb-4 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <p className="text-xs uppercase tracking-[0.25em] text-slate-400">Now playing</p>
+                <h2 className="font-display text-2xl text-white">{challenge.title}</h2>
+              </div>
+              <div className="flex items-center gap-4 text-sm text-slate-200">
+                <span className="rounded-full border border-aurora/50 bg-aurora/10 px-4 py-1 font-semibold text-aurora">
+                  {formatTime(timeRemaining)}
+                </span>
+                <span className="text-slate-300">Accuracy {accuracy}%</span>
+              </div>
+            </header>
+
+            <div className="mt-6">
+              <div className="h-2 w-full overflow-hidden rounded-full bg-white/10">
+                <div
+                  className="h-full rounded-full bg-gradient-to-r from-aurora to-ember transition-all"
+                  style={{ width: `${progress}%` }}
+                />
+              </div>
+              <div className="mt-3 flex items-center justify-between text-xs uppercase tracking-widest text-slate-400">
+                <span>
+                  Question {Math.min(answeredCount + 1, prompts.length)} / {prompts.length}
+                </span>
+                <span>Combo streak: {combo}</span>
+              </div>
+            </div>
+
+            <div className="mt-6 space-y-5">
+              {currentPrompt ? (
+                <>
+                  <motion.h3 layout className="font-display text-xl text-white">
+                    {currentPrompt.question}
+                  </motion.h3>
+                  <div className="grid gap-3">
+                    {currentPrompt.choices.map((choice, index) => {
+                      const isSelected = selectedChoice === index;
+                      const isCorrectChoice = currentPrompt.correctIndex === index;
+                      const showState = showFeedback && (isSelected || isCorrectChoice);
+
+                      return (
+                        <motion.button
+                          key={choice}
+                          whileHover={{ scale: selectedChoice === null ? 1.02 : 1 }}
+                          whileTap={{ scale: selectedChoice === null ? 0.98 : 1 }}
+                          disabled={selectedChoice !== null}
+                          onClick={() => handleSelect(index)}
+                          className={`rounded-2xl border px-4 py-3 text-left text-sm font-medium transition-all ${
+                            showState
+                              ? isCorrectChoice
+                                ? 'border-aurora bg-aurora/10 text-aurora'
+                                : 'border-ember bg-ember/10 text-ember'
+                              : 'border-white/10 bg-white/5 text-slate-100 hover:border-aurora/40 hover:bg-aurora/10'
+                          }`}
+                        >
+                          {choice}
+                        </motion.button>
+                      );
+                    })}
+                  </div>
+
+                  {showFeedback && lastResult && (
+                    <div
+                      className={`rounded-2xl border px-4 py-3 text-sm ${
+                        lastResult.correct
+                          ? 'border-aurora/40 bg-aurora/10 text-aurora'
+                          : 'border-ember/40 bg-ember/10 text-ember'
+                      }`}
+                    >
+                      {lastResult.correct ? 'Nice! Combo climbing.' : 'Combo reset. Shake it off and keep going!'}
+                      {showHint && <p className="mt-2 text-xs text-slate-200">Hint: {currentPrompt.hint}</p>}
+                    </div>
+                  )}
+                </>
+              ) : (
+                <p className="text-center text-sm text-slate-300">
+                  No prompts available for this challenge just yet.
+                </p>
+              )}
+            </div>
+
+            <footer className="mt-8 flex justify-end">
+              {showFeedback ? (
+                <button
+                  onClick={handleNext}
+                  className="inline-flex items-center rounded-full bg-gradient-to-r from-aurora to-ember px-6 py-2 text-sm font-semibold text-midnight shadow-glow"
+                >
+                  {currentIndex >= prompts.length - 1 ? 'Finish Run' : 'Next Prompt'}
+                </button>
+              ) : (
+                <button
+                  onClick={() => finalizeRun(results, false)}
+                  className="inline-flex items-center rounded-full border border-white/20 px-6 py-2 text-sm font-semibold text-slate-200 transition hover:border-ember/60 hover:text-ember"
+                >
+                  Exit Session
+                </button>
+              )}
+            </footer>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+};

--- a/src/components/RewardCenter.tsx
+++ b/src/components/RewardCenter.tsx
@@ -1,14 +1,15 @@
 import { motion } from 'framer-motion';
-import { RewardBadge } from '../types';
+import { LeaderboardEntry, RewardBadge } from '../types';
 
 interface RewardCenterProps {
   badges: RewardBadge[];
   unlocked: string[];
   streak: number;
   totalPoints: number;
+  leaderboard: LeaderboardEntry[];
 }
 
-export const RewardCenter = ({ badges, unlocked, streak, totalPoints }: RewardCenterProps) => {
+export const RewardCenter = ({ badges, unlocked, streak, totalPoints, leaderboard }: RewardCenterProps) => {
   return (
     <section className="bg-white/5 border border-white/10 rounded-3xl px-6 py-6">
       <div className="flex items-center justify-between mb-4">
@@ -41,6 +42,29 @@ export const RewardCenter = ({ badges, unlocked, streak, totalPoints }: RewardCe
           );
         })}
       </div>
+
+      {leaderboard.length > 0 && (
+        <div className="mt-6 bg-white/5 border border-white/10 rounded-2xl p-4">
+          <h4 className="text-lg font-display text-white mb-3">Weekly Leaderboard</h4>
+          <ol className="space-y-2">
+            {leaderboard.map((entry, index) => (
+              <li key={entry.uid} className="flex items-center justify-between text-sm text-slate-200">
+                <span className="flex items-center gap-3">
+                  <span className="text-xs font-semibold text-slate-400 w-6">#{index + 1}</span>
+                  <span
+                    className="h-8 w-8 rounded-full border border-white/20 bg-cover bg-center"
+                    style={{
+                      background: entry.avatar || 'linear-gradient(135deg,#1d4ed8,#9333ea)',
+                    }}
+                  />
+                  <span className="font-medium">{entry.name}</span>
+                </span>
+                <span className="text-xs text-slate-300">{entry.points} XP</span>
+              </li>
+            ))}
+          </ol>
+        </div>
+      )}
     </section>
   );
 };

--- a/src/data/dailyChallenges.ts
+++ b/src/data/dailyChallenges.ts
@@ -16,6 +16,27 @@ export const dailyChallenges: DailyChallenge[] = [
       'Balance a linear equation before the timer blinks red.',
       'Approximate the area of a polygon by decomposing shapes.',
     ],
+    prompts: [
+      {
+        id: 'speed-sprint-1',
+        question: 'What is the probability of drawing two hearts consecutively from a standard 52-card deck without replacement?',
+        choices: ['(13/52) × (12/51)', '(13/52) × (13/52)', '(1/4) × (1/4)'],
+        correctIndex: 0,
+        hint: 'Remember that the total card count changes after the first draw.',
+      },
+      {
+        id: 'speed-sprint-2',
+        question: 'Solve for x: 3x - 4 = 2x + 5.',
+        choices: ['x = 9', 'x = -9', 'x = 1/9'],
+        correctIndex: 0,
+      },
+      {
+        id: 'speed-sprint-3',
+        question: 'A hexagon is decomposed into four congruent triangles each with area 6. What is the total area of the hexagon?',
+        choices: ['12', '18', '24'],
+        correctIndex: 2,
+      },
+    ],
   },
   {
     id: 'strategy-lab',
@@ -32,6 +53,26 @@ export const dailyChallenges: DailyChallenge[] = [
       'Design a diversified allocation for a $10k portfolio.',
       'Calculate expected outcomes for a product launch gamble.',
     ],
+    prompts: [
+      {
+        id: 'strategy-lab-1',
+        question: 'If Topic A has a 0.6 probability of appearing and Topic B has 0.4, which schedule maximizes expected coverage in 5 study blocks?',
+        choices: ['3 blocks for A, 2 for B', '4 blocks for B, 1 for A', 'Evenly split: 2.5 blocks each'],
+        correctIndex: 0,
+      },
+      {
+        id: 'strategy-lab-2',
+        question: 'A balanced $10k portfolio aims for 40% equities, 35% bonds, and the rest cash. How much is allocated to bonds?',
+        choices: ['$3,500', '$4,000', '$2,500'],
+        correctIndex: 0,
+      },
+      {
+        id: 'strategy-lab-3',
+        question: 'Launching a product has a 30% chance of high success ($12k gain) and 70% chance of low success ($3k gain). What is the expected gain?',
+        choices: ['$5,100', '$7,500', '$9,000'],
+        correctIndex: 0,
+      },
+    ],
   },
   {
     id: 'mystery-easter-egg',
@@ -47,6 +88,27 @@ export const dailyChallenges: DailyChallenge[] = [
       'Translate the pattern into a Fibonacci-like series.',
       'Predict the next glyph rotation angle.',
       'Explain the rule in 30 seconds to secure the badge.',
+    ],
+    prompts: [
+      {
+        id: 'mystery-easter-egg-1',
+        question: 'The signal shows 2, 3, 5, 8... What number continues the pattern?',
+        choices: ['11', '12', '13'],
+        correctIndex: 2,
+        hint: 'Each value is the sum of the previous two.',
+      },
+      {
+        id: 'mystery-easter-egg-2',
+        question: 'Glyph rotations increase by 45°. After 135°, what is the next angle?',
+        choices: ['150°', '180°', '225°'],
+        correctIndex: 1,
+      },
+      {
+        id: 'mystery-easter-egg-3',
+        question: 'To explain the rule quickly, what is the clearest summary?',
+        choices: ['The sequence doubles each step.', 'Each term is the sum of the prior two, mirrored by 45° rotations.', 'Every odd term repeats.'],
+        correctIndex: 1,
+      },
     ],
   },
 ];

--- a/src/hooks/useCloudProfile.ts
+++ b/src/hooks/useCloudProfile.ts
@@ -1,0 +1,329 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  collection,
+  doc,
+  limit,
+  onSnapshot,
+  orderBy,
+  query,
+  serverTimestamp,
+  setDoc,
+  writeBatch,
+  type DocumentData,
+  type FirestoreError,
+} from 'firebase/firestore';
+import { ensureAnonymousUser, getFirestoreDb, subscribeToAuthState } from '../services/firebase';
+import { LeaderboardEntry, UserProfile } from '../types';
+import { usePersistentState } from './usePersistentState';
+
+export type DailyRecord = {
+  date: string;
+  completed: string[];
+  updatedAt?: string;
+};
+
+const todayKey = () => new Date().toISOString().split('T')[0];
+
+export const initialDailyRecord: DailyRecord = { date: '', completed: [] };
+
+interface CloudProfileDoc extends DocumentData {
+  id: string;
+  name: string;
+  avatar: string;
+  focus: UserProfile['focus'];
+  unlockedModules: string[];
+  badges: string[];
+  streak: number;
+  lastPlayed: string;
+  onboardingScore: number;
+  totalPoints?: number;
+  completedModules?: string[];
+}
+
+type SyncPayload = {
+  profile?: UserProfile;
+  totalPoints?: number;
+  completedModules?: string[];
+  uidOverride?: string;
+};
+
+type RecordDailyRunPayload = {
+  date: string;
+  completed: string[];
+  pointsAwarded?: number;
+};
+
+export function useCloudProfile() {
+  const db = useMemo(() => getFirestoreDb(), []);
+
+  const [cachedProfile, setCachedProfile] = usePersistentState<UserProfile | null>('mathquest-profile', null);
+  const [cachedTotalPoints, setCachedTotalPoints] = usePersistentState<number>('mathquest-total-points', 0);
+  const [cachedCompletedModules, setCachedCompletedModules] = usePersistentState<string[]>(
+    'mathquest-completed-modules',
+    []
+  );
+  const [cachedDailyRecord, setCachedDailyRecord] = usePersistentState<DailyRecord>(
+    'mathquest-daily-record',
+    initialDailyRecord
+  );
+
+  const [uid, setUid] = useState<string | null>(null);
+  const [profile, setProfile] = useState<UserProfile | null>(cachedProfile);
+  const [totalPoints, setTotalPoints] = useState<number>(cachedTotalPoints);
+  const [completedModules, setCompletedModules] = useState<string[]>(cachedCompletedModules);
+  const [dailyRecord, setDailyRecord] = useState<DailyRecord>(cachedDailyRecord);
+  const [leaderboard, setLeaderboard] = useState<LeaderboardEntry[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    const unsubscribe = subscribeToAuthState((nextUid) => {
+      if (nextUid) {
+        setUid(nextUid);
+      } else {
+        void ensureAnonymousUser().then((generatedUid) => setUid(generatedUid));
+      }
+    });
+
+    return () => {
+      unsubscribe();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!uid) {
+      return;
+    }
+
+    const profileRef = doc(db, 'profiles', uid);
+
+    const unsubscribe = onSnapshot(
+      profileRef,
+      (snapshot) => {
+        if (snapshot.exists()) {
+          const data = snapshot.data() as CloudProfileDoc;
+          const nextProfile: UserProfile = {
+            id: uid,
+            name: data.name,
+            avatar: data.avatar,
+            focus: data.focus,
+            unlockedModules: data.unlockedModules ?? [],
+            badges: data.badges ?? [],
+            streak: data.streak ?? 0,
+            lastPlayed: data.lastPlayed ?? '',
+            onboardingScore: data.onboardingScore ?? 0,
+          };
+
+          setProfile(nextProfile);
+          setCachedProfile(nextProfile);
+
+          if (typeof data.totalPoints === 'number') {
+            setTotalPoints(data.totalPoints);
+            setCachedTotalPoints(data.totalPoints);
+          }
+
+          if (Array.isArray(data.completedModules)) {
+            setCompletedModules(data.completedModules);
+            setCachedCompletedModules(data.completedModules);
+          }
+        } else {
+          setProfile(cachedProfile);
+          setTotalPoints(cachedTotalPoints);
+          setCompletedModules(cachedCompletedModules);
+        }
+        setLoading(false);
+      },
+      (error: FirestoreError) => {
+        console.error('Failed to read profile document', error);
+        setLoading(false);
+      }
+    );
+
+    return () => unsubscribe();
+  }, [cachedCompletedModules, cachedProfile, cachedTotalPoints, db, setCachedCompletedModules, setCachedProfile, setCachedTotalPoints, uid]);
+
+  useEffect(() => {
+    if (!uid) {
+      return;
+    }
+
+    const today = todayKey();
+    const dailyRunRef = doc(db, 'dailyRuns', uid, 'runs', today);
+
+    const unsubscribe = onSnapshot(dailyRunRef, (snapshot) => {
+      if (snapshot.exists()) {
+        const data = snapshot.data();
+        const record: DailyRecord = {
+          date: today,
+          completed: Array.isArray(data.completedChallenges) ? data.completedChallenges : [],
+          updatedAt: data.updatedAt?.toDate?.().toISOString(),
+        };
+
+        setDailyRecord(record);
+        setCachedDailyRecord(record);
+      } else if (cachedDailyRecord.date === today) {
+        setDailyRecord(cachedDailyRecord);
+      } else {
+        setDailyRecord(initialDailyRecord);
+      }
+    });
+
+    return () => unsubscribe();
+  }, [cachedDailyRecord, db, setCachedDailyRecord, uid]);
+
+  useEffect(() => {
+    const leaderboardQuery = query(
+      collection(db, 'leaderboards', 'weekly', 'entries'),
+      orderBy('points', 'desc'),
+      limit(10)
+    );
+
+    const unsubscribe = onSnapshot(leaderboardQuery, (snapshot) => {
+      const entries: LeaderboardEntry[] = snapshot.docs.map((docSnapshot) => {
+        const data = docSnapshot.data();
+        return {
+          uid: docSnapshot.id,
+          name: data.name ?? 'Adventurer',
+          avatar: data.avatar ?? '',
+          points: data.points ?? 0,
+        } as LeaderboardEntry;
+      });
+      setLeaderboard(entries);
+    });
+
+    return () => unsubscribe();
+  }, [db]);
+
+  const syncProfile = useCallback(
+    async ({ profile: nextProfileCandidate, totalPoints: nextPointsCandidate, completedModules: nextCompletedCandidate, uidOverride }: SyncPayload) => {
+      const targetUid = uidOverride ?? uid;
+      if (!targetUid) {
+        return;
+      }
+
+      const nextProfile = nextProfileCandidate ?? profile;
+      if (!nextProfile) {
+        return;
+      }
+
+      const nextPoints =
+        typeof nextPointsCandidate === 'number' ? nextPointsCandidate : typeof totalPoints === 'number' ? totalPoints : 0;
+      const nextCompleted = nextCompletedCandidate ?? completedModules;
+
+      setUid(targetUid);
+      setProfile(nextProfile);
+      setCachedProfile(nextProfile);
+
+      if (typeof nextPointsCandidate === 'number') {
+        setTotalPoints(nextPoints);
+        setCachedTotalPoints(nextPoints);
+      }
+
+      if (nextCompletedCandidate) {
+        setCompletedModules(nextCompleted);
+        setCachedCompletedModules(nextCompleted);
+      }
+
+      const batch = writeBatch(db);
+      const profileRef = doc(db, 'profiles', targetUid);
+      batch.set(
+        profileRef,
+        {
+          ...nextProfile,
+          totalPoints: nextPoints,
+          completedModules: nextCompleted,
+          updatedAt: serverTimestamp(),
+        },
+        { merge: true }
+      );
+
+      if (typeof nextPointsCandidate === 'number') {
+        const leaderboardRef = doc(db, 'leaderboards', 'weekly', 'entries', targetUid);
+        batch.set(
+          leaderboardRef,
+          {
+            uid: targetUid,
+            name: nextProfile.name,
+            avatar: nextProfile.avatar,
+            points: nextPoints,
+            updatedAt: serverTimestamp(),
+          },
+          { merge: true }
+        );
+      }
+
+      await batch.commit();
+    },
+    [
+      completedModules,
+      db,
+      profile,
+      setCachedCompletedModules,
+      setCachedProfile,
+      setCachedTotalPoints,
+      setUid,
+      totalPoints,
+      uid,
+    ]
+  );
+
+  const recordDailyRun = useCallback(
+    async ({ date, completed, pointsAwarded }: RecordDailyRunPayload) => {
+      const targetUid = uid;
+      if (!targetUid) {
+        return;
+      }
+
+      const optimisticRecord: DailyRecord = {
+        date,
+        completed,
+        updatedAt: new Date().toISOString(),
+      };
+      setDailyRecord(optimisticRecord);
+      setCachedDailyRecord(optimisticRecord);
+
+      const dailyRunRef = doc(db, 'dailyRuns', targetUid, 'runs', date);
+      const payload: Record<string, unknown> = {
+        completedChallenges: completed,
+        updatedAt: serverTimestamp(),
+      };
+      if (typeof pointsAwarded === 'number') {
+        payload.pointsAwarded = pointsAwarded;
+      }
+      await setDoc(dailyRunRef, payload, { merge: true });
+    },
+    [db, setCachedDailyRecord, uid]
+  );
+
+  const completeOnboarding = useCallback(
+    async (incomingProfile: UserProfile) => {
+      const ensuredUid = uid ?? (await ensureAnonymousUser());
+      const normalizedProfile: UserProfile = {
+        ...incomingProfile,
+        id: ensuredUid,
+      };
+
+      await syncProfile({
+        profile: normalizedProfile,
+        totalPoints: 0,
+        completedModules: normalizedProfile.unlockedModules,
+        uidOverride: ensuredUid,
+      });
+
+      return normalizedProfile;
+    },
+    [syncProfile, uid]
+  );
+
+  return {
+    uid,
+    loading,
+    profile,
+    totalPoints,
+    completedModules,
+    dailyRecord,
+    leaderboard,
+    syncProfile,
+    recordDailyRun,
+    completeOnboarding,
+  };
+}

--- a/src/services/firebase.ts
+++ b/src/services/firebase.ts
@@ -1,0 +1,82 @@
+import { FirebaseApp, getApps, initializeApp } from 'firebase/app';
+import { getAuth, onAuthStateChanged, signInAnonymously, type Auth } from 'firebase/auth';
+import { getFirestore, type Firestore } from 'firebase/firestore';
+
+interface FirebaseEnvConfig {
+  apiKey: string;
+  authDomain: string;
+  projectId: string;
+  storageBucket: string;
+  messagingSenderId: string;
+  appId: string;
+}
+
+let app: FirebaseApp | null = null;
+let authInstance: Auth | null = null;
+let firestoreInstance: Firestore | null = null;
+
+function readFirebaseConfig(): FirebaseEnvConfig {
+  const env = (import.meta as ImportMeta & { env: Record<string, string | undefined> }).env;
+  const config: FirebaseEnvConfig = {
+    apiKey: env.VITE_FIREBASE_API_KEY ?? '',
+    authDomain: env.VITE_FIREBASE_AUTH_DOMAIN ?? '',
+    projectId: env.VITE_FIREBASE_PROJECT_ID ?? '',
+    storageBucket: env.VITE_FIREBASE_STORAGE_BUCKET ?? '',
+    messagingSenderId: env.VITE_FIREBASE_MESSAGING_SENDER_ID ?? '',
+    appId: env.VITE_FIREBASE_APP_ID ?? '',
+  };
+
+  const missing = Object.entries(config)
+    .filter(([, value]) => !value)
+    .map(([key]) => key);
+
+  if (missing.length > 0) {
+    console.warn(`Missing Firebase configuration values: ${missing.join(', ')}`);
+  }
+
+  return config;
+}
+
+function ensureApp(): FirebaseApp {
+  if (app) {
+    return app;
+  }
+
+  if (getApps().length) {
+    app = getApps()[0]!;
+  } else {
+    app = initializeApp(readFirebaseConfig());
+  }
+
+  return app;
+}
+
+export function getFirebaseAuth(): Auth {
+  if (!authInstance) {
+    authInstance = getAuth(ensureApp());
+  }
+  return authInstance;
+}
+
+export function getFirestoreDb(): Firestore {
+  if (!firestoreInstance) {
+    firestoreInstance = getFirestore(ensureApp());
+  }
+  return firestoreInstance;
+}
+
+export async function ensureAnonymousUser(): Promise<string> {
+  const auth = getFirebaseAuth();
+
+  if (auth.currentUser) {
+    return auth.currentUser.uid;
+  }
+
+  const result = await signInAnonymously(auth);
+  return result.user.uid;
+}
+
+export function subscribeToAuthState(callback: (uid: string | null) => void) {
+  const auth = getFirebaseAuth();
+  return onAuthStateChanged(auth, (user) => callback(user ? user.uid : null));
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,31 @@ export interface LearningModule {
   miniGame: ModuleMiniGame;
 }
 
+export interface DailyChallengePrompt {
+  id: string;
+  question: string;
+  choices: string[];
+  correctIndex: number;
+  hint?: string;
+}
+
+export interface DailyChallengeRunResult {
+  promptId: string;
+  correct: boolean;
+}
+
+export interface DailyChallengeRunSummary {
+  challengeId: string;
+  solved: number;
+  correct: number;
+  accuracy: number;
+  bestCombo: number;
+  completed: boolean;
+  allSolved: boolean;
+  timeElapsedSeconds: number;
+  results: DailyChallengeRunResult[];
+}
+
 export interface DailyChallenge {
   id: string;
   title: string;
@@ -47,6 +72,10 @@ export interface DailyChallenge {
     streakBonus?: number;
   };
   tasks: string[];
+  prompts?: DailyChallengePrompt[];
+  scoring?: {
+    comboBonus?: number;
+  };
 }
 
 export interface RewardBadge {
@@ -60,6 +89,13 @@ export interface ProgressSnapshot {
   unlockedCount: number;
   totalCount: number;
   completionRate: number;
+}
+
+export interface LeaderboardEntry {
+  uid: string;
+  name: string;
+  avatar: string;
+  points: number;
 }
 
 export interface ScenarioParameter {

--- a/src/utils/gameLogic.ts
+++ b/src/utils/gameLogic.ts
@@ -2,17 +2,24 @@ import { DailyChallenge, LearningModule, ProgressSnapshot, RewardBadge, UserProf
 
 const todayKey = () => new Date().toISOString().split('T')[0];
 
-export function evaluateStreak(profile: UserProfile, completedToday: boolean): UserProfile {
+export function evaluateStreak(
+  profile: UserProfile,
+  completedToday: boolean,
+  lastServerPlayed?: string
+): UserProfile {
   const today = todayKey();
+  const candidate = lastServerPlayed ?? profile.lastPlayed;
+  const lastPlayed =
+    typeof candidate === 'string' && candidate.includes('T') ? candidate.split('T')[0] ?? '' : candidate ?? '';
 
   if (!completedToday) {
-    if (profile.lastPlayed && profile.lastPlayed !== today) {
-      return { ...profile, streak: 0 };
+    if (lastPlayed && lastPlayed !== today) {
+      return { ...profile, streak: 0, lastPlayed };
     }
-    return profile;
+    return { ...profile, lastPlayed: lastPlayed || profile.lastPlayed };
   }
 
-  const updatedStreak = profile.lastPlayed === today ? profile.streak : profile.streak + 1;
+  const updatedStreak = lastPlayed === today ? profile.streak : profile.streak + 1;
   return {
     ...profile,
     streak: updatedStreak,


### PR DESCRIPTION
## Summary
- add a Firebase-backed `useCloudProfile` hook and leaderboard-aware reward center with onboarding fixes
- wire the new daily challenge runner, challenge summary, and Firestore-backed streak logic into the app
- document Firebase configuration and extend challenge data with structured prompts

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd7e85357c832faf3805d9665d86c7